### PR TITLE
fix(deps): npm audit fix to clear high-severity advisories blocking CI

### DIFF
--- a/.github/workflows/build-and-deploy.yml
+++ b/.github/workflows/build-and-deploy.yml
@@ -27,7 +27,9 @@ jobs:
             - run: npm ci
             - run: npm run lint
             - run: npm run prettier:check
-            - run: npm audit --audit-level=high
+            # Audit production deps only: this is a static frontend, so dev/release
+            # tooling (semantic-release's bundled npm/undici, etc.) never ships.
+            - run: npm audit --omit=dev --audit-level=high
 
     deploy-preview:
         if: github.event_name == 'pull_request'

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,11 +1,11 @@
 {
-    "name": "sorting-animation",
+    "name": "algorythm",
     "version": "2.11.0",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
-            "name": "sorting-animation",
+            "name": "algorythm",
             "version": "2.11.0",
             "license": "MIT",
             "dependencies": {
@@ -99,12 +99,12 @@
             "license": "MIT"
         },
         "node_modules/@babel/code-frame": {
-            "version": "7.29.0",
-            "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.29.0.tgz",
-            "integrity": "sha512-9NhCeYjq9+3uxgdtp20LSiJXJvN0FeCtNGpJxuMFZ1Kv3cWUNb6DOhJwUvcVCzKGR66cw4njwM6hrJLqgOwbcw==",
+            "version": "7.29.7",
+            "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.29.7.tgz",
+            "integrity": "sha512-Aup7aUOfpbAUg2ROOJN6Iw5f9DMBlzu0mIkm/malLQFN/YQgO48wCj0Kxa3sEHJvPVFg7siR+qRInwXd2qhQKw==",
             "license": "MIT",
             "dependencies": {
-                "@babel/helper-validator-identifier": "^7.28.5",
+                "@babel/helper-validator-identifier": "^7.29.7",
                 "js-tokens": "^4.0.0",
                 "picocolors": "^1.1.1"
             },
@@ -113,29 +113,29 @@
             }
         },
         "node_modules/@babel/compat-data": {
-            "version": "7.29.3",
-            "resolved": "https://registry.npmjs.org/@babel/compat-data/-/compat-data-7.29.3.tgz",
-            "integrity": "sha512-LIVqM46zQWZhj17qA8wb4nW/ixr2y1Nw+r1etiAWgRM6U1IqP+LNhL1yg440jYZR72jCWcWbLWzIosH+uP1fqg==",
+            "version": "7.29.7",
+            "resolved": "https://registry.npmjs.org/@babel/compat-data/-/compat-data-7.29.7.tgz",
+            "integrity": "sha512-locTkQyKvwIEgBzVrn8693ebc97F2U8ZHjbXwDXJ5Fn2TCpNwTlKcaKLkdHop5c/icOFE7qt7Q9JC5hnKNa6Gg==",
             "license": "MIT",
             "engines": {
                 "node": ">=6.9.0"
             }
         },
         "node_modules/@babel/core": {
-            "version": "7.29.0",
-            "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.29.0.tgz",
-            "integrity": "sha512-CGOfOJqWjg2qW/Mb6zNsDm+u5vFQ8DxXfbM09z69p5Z6+mE1ikP2jUXw+j42Pf1XTYED2Rni5f95npYeuwMDQA==",
+            "version": "7.29.7",
+            "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.29.7.tgz",
+            "integrity": "sha512-RgHBCvtjbOK2gXSNBNIkNoEc9qoVEtau3hj8gEqKQuL3HZAibKarWFEI3Lfm6EYKkLalOh8eSrj9b+ch9H/VBA==",
             "license": "MIT",
             "dependencies": {
-                "@babel/code-frame": "^7.29.0",
-                "@babel/generator": "^7.29.0",
-                "@babel/helper-compilation-targets": "^7.28.6",
-                "@babel/helper-module-transforms": "^7.28.6",
-                "@babel/helpers": "^7.28.6",
-                "@babel/parser": "^7.29.0",
-                "@babel/template": "^7.28.6",
-                "@babel/traverse": "^7.29.0",
-                "@babel/types": "^7.29.0",
+                "@babel/code-frame": "^7.29.7",
+                "@babel/generator": "^7.29.7",
+                "@babel/helper-compilation-targets": "^7.29.7",
+                "@babel/helper-module-transforms": "^7.29.7",
+                "@babel/helpers": "^7.29.7",
+                "@babel/parser": "^7.29.7",
+                "@babel/template": "^7.29.7",
+                "@babel/traverse": "^7.29.7",
+                "@babel/types": "^7.29.7",
                 "@jridgewell/remapping": "^2.3.5",
                 "convert-source-map": "^2.0.0",
                 "debug": "^4.1.0",
@@ -161,13 +161,13 @@
             }
         },
         "node_modules/@babel/generator": {
-            "version": "7.29.1",
-            "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.29.1.tgz",
-            "integrity": "sha512-qsaF+9Qcm2Qv8SRIMMscAvG4O3lJ0F1GuMo5HR/Bp02LopNgnZBC/EkbevHFeGs4ls/oPz9v+Bsmzbkbe+0dUw==",
+            "version": "7.29.7",
+            "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.29.7.tgz",
+            "integrity": "sha512-DkXD5OJQaAQIdZ1bt3UZdEnHAn9Imd3IVBdX03UFe+ony9Ojw5pzr9YVKGDY1jt+Gcn/FnGkNf8r+Vj5NOJWtQ==",
             "license": "MIT",
             "dependencies": {
-                "@babel/parser": "^7.29.0",
-                "@babel/types": "^7.29.0",
+                "@babel/parser": "^7.29.7",
+                "@babel/types": "^7.29.7",
                 "@jridgewell/gen-mapping": "^0.3.12",
                 "@jridgewell/trace-mapping": "^0.3.28",
                 "jsesc": "^3.0.2"
@@ -189,13 +189,13 @@
             }
         },
         "node_modules/@babel/helper-compilation-targets": {
-            "version": "7.28.6",
-            "resolved": "https://registry.npmjs.org/@babel/helper-compilation-targets/-/helper-compilation-targets-7.28.6.tgz",
-            "integrity": "sha512-JYtls3hqi15fcx5GaSNL7SCTJ2MNmjrkHXg4FSpOA/grxK8KwyZ5bubHsCq8FXCkua6xhuaaBit+3b7+VZRfcA==",
+            "version": "7.29.7",
+            "resolved": "https://registry.npmjs.org/@babel/helper-compilation-targets/-/helper-compilation-targets-7.29.7.tgz",
+            "integrity": "sha512-wem6WaBj4NaVYVdNhLPPVacES6ZJ+KBBfSkTMD3YZxbP3rm3Di85tJU5ljaUNhaOynt+Aj0xruhYuzQBt8n71g==",
             "license": "MIT",
             "dependencies": {
-                "@babel/compat-data": "^7.28.6",
-                "@babel/helper-validator-option": "^7.27.1",
+                "@babel/compat-data": "^7.29.7",
+                "@babel/helper-validator-option": "^7.29.7",
                 "browserslist": "^4.24.0",
                 "lru-cache": "^5.1.1",
                 "semver": "^6.3.1"
@@ -214,36 +214,36 @@
             }
         },
         "node_modules/@babel/helper-globals": {
-            "version": "7.28.0",
-            "resolved": "https://registry.npmjs.org/@babel/helper-globals/-/helper-globals-7.28.0.tgz",
-            "integrity": "sha512-+W6cISkXFa1jXsDEdYA8HeevQT/FULhxzR99pxphltZcVaugps53THCeiWA8SguxxpSp3gKPiuYfSWopkLQ4hw==",
+            "version": "7.29.7",
+            "resolved": "https://registry.npmjs.org/@babel/helper-globals/-/helper-globals-7.29.7.tgz",
+            "integrity": "sha512-3nQVUAtvkKH9zahfWgw96Jc/uFOmjACE1kQz82E2lqWmHBgjzbNlsC22nuQTfahmWeQtTq5nQ/4Nnd2A1wj4zA==",
             "license": "MIT",
             "engines": {
                 "node": ">=6.9.0"
             }
         },
         "node_modules/@babel/helper-module-imports": {
-            "version": "7.28.6",
-            "resolved": "https://registry.npmjs.org/@babel/helper-module-imports/-/helper-module-imports-7.28.6.tgz",
-            "integrity": "sha512-l5XkZK7r7wa9LucGw9LwZyyCUscb4x37JWTPz7swwFE/0FMQAGpiWUZn8u9DzkSBWEcK25jmvubfpw2dnAMdbw==",
+            "version": "7.29.7",
+            "resolved": "https://registry.npmjs.org/@babel/helper-module-imports/-/helper-module-imports-7.29.7.tgz",
+            "integrity": "sha512-ejHwrQQYcm9xnTivShn2IDOlIzInN34AXskvq9QicvCtEzq1Vzclu/tKF8Jq1Cg8JG2GL6/EmjgsCT7lXepE3g==",
             "license": "MIT",
             "dependencies": {
-                "@babel/traverse": "^7.28.6",
-                "@babel/types": "^7.28.6"
+                "@babel/traverse": "^7.29.7",
+                "@babel/types": "^7.29.7"
             },
             "engines": {
                 "node": ">=6.9.0"
             }
         },
         "node_modules/@babel/helper-module-transforms": {
-            "version": "7.28.6",
-            "resolved": "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.28.6.tgz",
-            "integrity": "sha512-67oXFAYr2cDLDVGLXTEABjdBJZ6drElUSI7WKp70NrpyISso3plG9SAGEF6y7zbha/wOzUByWWTJvEDVNIUGcA==",
+            "version": "7.29.7",
+            "resolved": "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.29.7.tgz",
+            "integrity": "sha512-UPUVSyXbOh627KiCIGQSgwWzGeBKLkaJ9PJEdrngIwMSzxLR4jS4+f1f1jb7VzBbg8nFLaYotvVPFCTqdrmTAg==",
             "license": "MIT",
             "dependencies": {
-                "@babel/helper-module-imports": "^7.28.6",
-                "@babel/helper-validator-identifier": "^7.28.5",
-                "@babel/traverse": "^7.28.6"
+                "@babel/helper-module-imports": "^7.29.7",
+                "@babel/helper-validator-identifier": "^7.29.7",
+                "@babel/traverse": "^7.29.7"
             },
             "engines": {
                 "node": ">=6.9.0"
@@ -262,52 +262,52 @@
             }
         },
         "node_modules/@babel/helper-string-parser": {
-            "version": "7.27.1",
-            "resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-7.27.1.tgz",
-            "integrity": "sha512-qMlSxKbpRlAridDExk92nSobyDdpPijUq2DW6oDnUqd0iOGxmQjyqhMIihI9+zv4LPyZdRje2cavWPbCbWm3eA==",
+            "version": "7.29.7",
+            "resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-7.29.7.tgz",
+            "integrity": "sha512-Pb5ijPrZ89GDH8223L4UP8i6QApWxs04RbPQJTeWDV0/keR2E36MeKnyr6LYmUUvqRRI+Iv87SuF1W6ErINzYw==",
             "license": "MIT",
             "engines": {
                 "node": ">=6.9.0"
             }
         },
         "node_modules/@babel/helper-validator-identifier": {
-            "version": "7.28.5",
-            "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.28.5.tgz",
-            "integrity": "sha512-qSs4ifwzKJSV39ucNjsvc6WVHs6b7S03sOh2OcHF9UHfVPqWWALUsNUVzhSBiItjRZoLHx7nIarVjqKVusUZ1Q==",
+            "version": "7.29.7",
+            "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.29.7.tgz",
+            "integrity": "sha512-qehxGkRj55h/ff8EMaJ+cYhyaKlHIxqYDn682wQD7RNp9UujOQsHog2uS0r2vzr4pW+sXf90NeeayjcNaX3fFg==",
             "license": "MIT",
             "engines": {
                 "node": ">=6.9.0"
             }
         },
         "node_modules/@babel/helper-validator-option": {
-            "version": "7.27.1",
-            "resolved": "https://registry.npmjs.org/@babel/helper-validator-option/-/helper-validator-option-7.27.1.tgz",
-            "integrity": "sha512-YvjJow9FxbhFFKDSuFnVCe2WxXk1zWc22fFePVNEaWJEu8IrZVlda6N0uHwzZrUM1il7NC9Mlp4MaJYbYd9JSg==",
+            "version": "7.29.7",
+            "resolved": "https://registry.npmjs.org/@babel/helper-validator-option/-/helper-validator-option-7.29.7.tgz",
+            "integrity": "sha512-N9ZErrD+yW5geCDtBqnOoxmR8+tNKiGuxKlDpuJxfsqpa2dFcexaziGAE/qoHLiDDreVNMupxGmSoNlyvsA3gw==",
             "license": "MIT",
             "engines": {
                 "node": ">=6.9.0"
             }
         },
         "node_modules/@babel/helpers": {
-            "version": "7.29.2",
-            "resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.29.2.tgz",
-            "integrity": "sha512-HoGuUs4sCZNezVEKdVcwqmZN8GoHirLUcLaYVNBK2J0DadGtdcqgr3BCbvH8+XUo4NGjNl3VOtSjEKNzqfFgKw==",
+            "version": "7.29.7",
+            "resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.29.7.tgz",
+            "integrity": "sha512-1k2lAGRMfHTcwuNYcCNUmaUffmQv8KWMfh2iJUUeRlwlwH4FdNG7mfPI10NPfLHJFThE4Tyr4mv7kTNZOiPuBg==",
             "license": "MIT",
             "dependencies": {
-                "@babel/template": "^7.28.6",
-                "@babel/types": "^7.29.0"
+                "@babel/template": "^7.29.7",
+                "@babel/types": "^7.29.7"
             },
             "engines": {
                 "node": ">=6.9.0"
             }
         },
         "node_modules/@babel/parser": {
-            "version": "7.29.3",
-            "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.29.3.tgz",
-            "integrity": "sha512-b3ctpQwp+PROvU/cttc4OYl4MzfJUWy6FZg+PMXfzmt/+39iHVF0sDfqay8TQM3JA2EUOyKcFZt75jWriQijsA==",
+            "version": "7.29.7",
+            "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.29.7.tgz",
+            "integrity": "sha512-hnORnjP/1P/zFEndoeX+n+t1RwWRJiJpM/jO7FW32Kn9r5+sJB2JWOdYo4L6k78j15eCwY3Gm/7364B1EMwtNg==",
             "license": "MIT",
             "dependencies": {
-                "@babel/types": "^7.29.0"
+                "@babel/types": "^7.29.7"
             },
             "bin": {
                 "parser": "bin/babel-parser.js"
@@ -364,31 +364,31 @@
             }
         },
         "node_modules/@babel/template": {
-            "version": "7.28.6",
-            "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.28.6.tgz",
-            "integrity": "sha512-YA6Ma2KsCdGb+WC6UpBVFJGXL58MDA6oyONbjyF/+5sBgxY/dwkhLogbMT2GXXyU84/IhRw/2D1Os1B/giz+BQ==",
+            "version": "7.29.7",
+            "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.29.7.tgz",
+            "integrity": "sha512-puq+Gf35oI24FeN11LkoUQFqv9uwNeWpxXZi/Ji3rRIoKAzKnxRaZ+Gkj0vKS9ZCiTESfng1N9LyOyXvo+m+Gg==",
             "license": "MIT",
             "dependencies": {
-                "@babel/code-frame": "^7.28.6",
-                "@babel/parser": "^7.28.6",
-                "@babel/types": "^7.28.6"
+                "@babel/code-frame": "^7.29.7",
+                "@babel/parser": "^7.29.7",
+                "@babel/types": "^7.29.7"
             },
             "engines": {
                 "node": ">=6.9.0"
             }
         },
         "node_modules/@babel/traverse": {
-            "version": "7.29.0",
-            "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.29.0.tgz",
-            "integrity": "sha512-4HPiQr0X7+waHfyXPZpWPfWL/J7dcN1mx9gL6WdQVMbPnF3+ZhSMs8tCxN7oHddJE9fhNE7+lxdnlyemKfJRuA==",
+            "version": "7.29.7",
+            "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.29.7.tgz",
+            "integrity": "sha512-EhlfNQtZ+NK22w5BM61ciuiq1m58ed33Wr1Xan//ZRTy6hgjnwyCffRYwzsGXdASJSUJ1guZILsErh1eQcl+zw==",
             "license": "MIT",
             "dependencies": {
-                "@babel/code-frame": "^7.29.0",
-                "@babel/generator": "^7.29.0",
-                "@babel/helper-globals": "^7.28.0",
-                "@babel/parser": "^7.29.0",
-                "@babel/template": "^7.28.6",
-                "@babel/types": "^7.29.0",
+                "@babel/code-frame": "^7.29.7",
+                "@babel/generator": "^7.29.7",
+                "@babel/helper-globals": "^7.29.7",
+                "@babel/parser": "^7.29.7",
+                "@babel/template": "^7.29.7",
+                "@babel/types": "^7.29.7",
                 "debug": "^4.3.1"
             },
             "engines": {
@@ -396,13 +396,13 @@
             }
         },
         "node_modules/@babel/types": {
-            "version": "7.29.0",
-            "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.29.0.tgz",
-            "integrity": "sha512-LwdZHpScM4Qz8Xw2iKSzS+cfglZzJGvofQICy7W7v4caru4EaAmyUuO6BGrbyQ2mYV11W0U8j5mBhd14dd3B0A==",
+            "version": "7.29.7",
+            "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.29.7.tgz",
+            "integrity": "sha512-4zBIxpPzowiZpusoFkyGVwakdRJUyuH5PxQ/PrqghfdFWWasvnCdPfQXHrenDai+gyLARulZjZowCOj6fjT4pA==",
             "license": "MIT",
             "dependencies": {
-                "@babel/helper-string-parser": "^7.27.1",
-                "@babel/helper-validator-identifier": "^7.28.5"
+                "@babel/helper-string-parser": "^7.29.7",
+                "@babel/helper-validator-identifier": "^7.29.7"
             },
             "engines": {
                 "node": ">=6.9.0"
@@ -3685,9 +3685,9 @@
             "license": "MIT"
         },
         "node_modules/baseline-browser-mapping": {
-            "version": "2.10.27",
-            "resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.10.27.tgz",
-            "integrity": "sha512-zEs/ufmZoUd7WftKpKyXaT6RFxpQ5Qm9xytKRHvJfxFV9DFJkZph9RvJ1LcOUi0Z1ZVijMte65JbILeV+8QQEA==",
+            "version": "2.10.38",
+            "resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.10.38.tgz",
+            "integrity": "sha512-31/02mVB4yuQU6adKk5SlY6m+mxDwUq5KZkyYgnLrrKl7TEm1+3PyDtDBz2kOv/wxZz41GHsvV1A/u6RmiyBvw==",
             "license": "Apache-2.0",
             "bin": {
                 "baseline-browser-mapping": "dist/cli.cjs"
@@ -3837,9 +3837,9 @@
             }
         },
         "node_modules/caniuse-lite": {
-            "version": "1.0.30001791",
-            "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001791.tgz",
-            "integrity": "sha512-yk0l/YSrOnFZk3UROpDLQD9+kC1l4meK/wed583AXrzoarMGJcbRi2Q4RaUYbKxYAsZ8sWmaSa/DsLmdBeI1vQ==",
+            "version": "1.0.30001799",
+            "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001799.tgz",
+            "integrity": "sha512-hG1bReV+OUU+MOqK4t/ZWI0tZOyz3rqS9XuhOUz1cIcbwBKjOyJEJuw9ER5JuNyqxNk8u/JUVbGibBOL1yrjFw==",
             "funding": [
                 {
                     "type": "opencollective",
@@ -4449,9 +4449,9 @@
             }
         },
         "node_modules/electron-to-chromium": {
-            "version": "1.5.349",
-            "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.349.tgz",
-            "integrity": "sha512-QsWVGyRuY07Aqb234QytTfwd5d9AJlfNIQ5wIOl1L+PZDzI9d9+Fn0FRale/QYlFxt/bUnB0/nLd1jFPGxGK1A==",
+            "version": "1.5.376",
+            "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.376.tgz",
+            "integrity": "sha512-cUVA7/RvbFTEuw/i3obUwDTRIXojaxkResf+ibByPFxjc6XK3VNtcQXV0NSbAlJ0FMjcJGgftVVB4Qo184EXvA==",
             "license": "ISC"
         },
         "node_modules/emoji-regex": {
@@ -5292,9 +5292,9 @@
             "license": "MIT"
         },
         "node_modules/fast-uri": {
-            "version": "3.1.0",
-            "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.0.tgz",
-            "integrity": "sha512-iPeeDKJSWf4IEOasVVrknXpaBV0IApz/gp7S2bb7Z4Lljbl2MGJRqInZiUrQwV16cpzw/D3S5j5Julj/gT52AA==",
+            "version": "3.1.2",
+            "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.2.tgz",
+            "integrity": "sha512-rVjf7ArG3LTk+FS6Yw81V1DLuZl1bRbNrev6Tmd/9RaroeeRRJhAt7jg/6YFxbvAQXUCavSoZhPPj6oOx+5KjQ==",
             "dev": true,
             "funding": [
                 {
@@ -6759,10 +6759,20 @@
             "license": "MIT"
         },
         "node_modules/js-yaml": {
-            "version": "4.1.1",
-            "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.1.tgz",
-            "integrity": "sha512-qQKT4zQxXl8lLwBtHMWwaTcGfFOZviOJet3Oy/xmGk2gZH677CJM9EvtfdSkgWcATZhj/55JZ0rmy3myCT5lsA==",
+            "version": "4.2.0",
+            "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.2.0.tgz",
+            "integrity": "sha512-ePWsvanv0DWuDRsW8dnt+R4jQ31SCRCQ7hhNcPXZPsoBZiemuZNYGf7adZdqX2D86j6rvKp3RpCxVTSb8WQlOw==",
             "dev": true,
+            "funding": [
+                {
+                    "type": "github",
+                    "url": "https://github.com/sponsors/puzrin"
+                },
+                {
+                    "type": "github",
+                    "url": "https://github.com/sponsors/nodeca"
+                }
+            ],
             "license": "MIT",
             "dependencies": {
                 "argparse": "^2.0.1"
@@ -7347,10 +7357,13 @@
             }
         },
         "node_modules/node-releases": {
-            "version": "2.0.38",
-            "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.38.tgz",
-            "integrity": "sha512-3qT/88Y3FbH/Kx4szpQQ4HzUbVrHPKTLVpVocKiLfoYvw9XSGOX2FmD2d6DrXbVYyAQTF2HeF6My8jmzx7/CRw==",
-            "license": "MIT"
+            "version": "2.0.48",
+            "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.48.tgz",
+            "integrity": "sha512-1uz8041X6LoI6ZSdZacM9lVY28vuzDlSKitnpbSNK0RfKoIJkX29NBPVEFXhnuSuEOA9Ww0xnPJ+ILWbGAv8DA==",
+            "license": "MIT",
+            "engines": {
+                "node": ">=18"
+            }
         },
         "node_modules/normalize-url": {
             "version": "9.0.0",
@@ -7372,9 +7385,9 @@
             "license": "MIT"
         },
         "node_modules/npm": {
-            "version": "11.13.0",
-            "resolved": "https://registry.npmjs.org/npm/-/npm-11.13.0.tgz",
-            "integrity": "sha512-cRmhaghDWA1lFgl3Ug4/VxDJdPBK/U+tNtnrl9kXunFqhWw1x4xL5txkNn7qzPuVfvXOmXyjHpMwsuk2uisbkg==",
+            "version": "11.17.0",
+            "resolved": "https://registry.npmjs.org/npm/-/npm-11.17.0.tgz",
+            "integrity": "sha512-PurxiZexEHDTE4SSaLI3ZrnbAGiZfeyUcQcxcP5D+hfytNAze/D1IzDuInTn9XVLIbAQUnQuSPXJx02LHjLvQw==",
             "bundleDependencies": [
                 "@isaacs/string-locale-compare",
                 "@npmcli/arborist",
@@ -7453,8 +7466,8 @@
             ],
             "dependencies": {
                 "@isaacs/string-locale-compare": "^1.1.0",
-                "@npmcli/arborist": "^9.4.3",
-                "@npmcli/config": "^10.8.1",
+                "@npmcli/arborist": "^9.8.0",
+                "@npmcli/config": "^10.11.0",
                 "@npmcli/fs": "^5.0.0",
                 "@npmcli/map-workspaces": "^5.0.3",
                 "@npmcli/metavuln-calculator": "^9.0.3",
@@ -7472,27 +7485,27 @@
                 "fs-minipass": "^3.0.3",
                 "glob": "^13.0.6",
                 "graceful-fs": "^4.2.11",
-                "hosted-git-info": "^9.0.2",
+                "hosted-git-info": "^9.0.3",
                 "ini": "^6.0.0",
                 "init-package-json": "^8.2.5",
                 "is-cidr": "^6.0.4",
                 "json-parse-even-better-errors": "^5.0.0",
                 "libnpmaccess": "^10.0.3",
-                "libnpmdiff": "^8.1.6",
-                "libnpmexec": "^10.2.6",
-                "libnpmfund": "^7.0.20",
+                "libnpmdiff": "^8.1.10",
+                "libnpmexec": "^10.3.0",
+                "libnpmfund": "^7.0.24",
                 "libnpmorg": "^8.0.1",
-                "libnpmpack": "^9.1.6",
-                "libnpmpublish": "^11.1.3",
+                "libnpmpack": "^9.1.10",
+                "libnpmpublish": "^11.2.0",
                 "libnpmsearch": "^9.0.1",
                 "libnpmteam": "^8.0.2",
-                "libnpmversion": "^8.0.3",
-                "make-fetch-happen": "^15.0.5",
+                "libnpmversion": "^8.0.4",
+                "make-fetch-happen": "^15.0.6",
                 "minimatch": "^10.2.5",
                 "minipass": "^7.1.3",
                 "minipass-pipeline": "^1.2.4",
                 "ms": "^2.1.2",
-                "node-gyp": "^12.3.0",
+                "node-gyp": "^12.4.0",
                 "nopt": "^9.0.0",
                 "npm-audit-report": "^7.0.0",
                 "npm-install-checks": "^8.0.0",
@@ -7502,16 +7515,16 @@
                 "npm-registry-fetch": "^19.1.1",
                 "npm-user-validate": "^4.0.0",
                 "p-map": "^7.0.4",
-                "pacote": "^21.5.0",
+                "pacote": "^21.5.1",
                 "parse-conflict-json": "^5.0.1",
                 "proc-log": "^6.1.0",
                 "qrcode-terminal": "^0.12.0",
                 "read": "^5.0.1",
-                "semver": "^7.7.4",
+                "semver": "^7.8.4",
                 "spdx-expression-parse": "^4.0.0",
                 "ssri": "^13.0.1",
                 "supports-color": "^10.2.2",
-                "tar": "^7.5.13",
+                "tar": "^7.5.16",
                 "text-table": "~0.2.0",
                 "tiny-relative-date": "^2.0.2",
                 "treeverse": "^3.0.0",
@@ -7567,7 +7580,7 @@
             "license": "ISC"
         },
         "node_modules/npm/node_modules/@npmcli/agent": {
-            "version": "4.0.0",
+            "version": "4.0.2",
             "dev": true,
             "inBundle": true,
             "license": "ISC",
@@ -7583,7 +7596,7 @@
             }
         },
         "node_modules/npm/node_modules/@npmcli/arborist": {
-            "version": "9.4.3",
+            "version": "9.8.0",
             "dev": true,
             "inBundle": true,
             "license": "ISC",
@@ -7631,7 +7644,7 @@
             }
         },
         "node_modules/npm/node_modules/@npmcli/config": {
-            "version": "10.8.1",
+            "version": "10.11.0",
             "dev": true,
             "inBundle": true,
             "license": "ISC",
@@ -7825,7 +7838,7 @@
             }
         },
         "node_modules/npm/node_modules/@sigstore/core": {
-            "version": "3.2.0",
+            "version": "3.2.1",
             "dev": true,
             "inBundle": true,
             "license": "Apache-2.0",
@@ -7873,13 +7886,13 @@
             }
         },
         "node_modules/npm/node_modules/@sigstore/verify": {
-            "version": "3.1.0",
+            "version": "3.1.1",
             "dev": true,
             "inBundle": true,
             "license": "Apache-2.0",
             "dependencies": {
                 "@sigstore/bundle": "^4.0.0",
-                "@sigstore/core": "^3.1.0",
+                "@sigstore/core": "^3.2.1",
                 "@sigstore/protobuf-specs": "^0.5.0"
             },
             "engines": {
@@ -7948,7 +7961,7 @@
             }
         },
         "node_modules/npm/node_modules/bin-links": {
-            "version": "6.0.0",
+            "version": "6.0.2",
             "dev": true,
             "inBundle": true,
             "license": "ISC",
@@ -7976,7 +7989,7 @@
             }
         },
         "node_modules/npm/node_modules/brace-expansion": {
-            "version": "5.0.5",
+            "version": "5.0.6",
             "dev": true,
             "inBundle": true,
             "license": "MIT",
@@ -8045,7 +8058,7 @@
             }
         },
         "node_modules/npm/node_modules/cidr-regex": {
-            "version": "5.0.4",
+            "version": "5.0.5",
             "dev": true,
             "inBundle": true,
             "license": "BSD-2-Clause",
@@ -8169,7 +8182,7 @@
             "license": "ISC"
         },
         "node_modules/npm/node_modules/hosted-git-info": {
-            "version": "9.0.2",
+            "version": "9.0.3",
             "dev": true,
             "inBundle": true,
             "license": "ISC",
@@ -8268,7 +8281,7 @@
             }
         },
         "node_modules/npm/node_modules/ip-address": {
-            "version": "10.1.0",
+            "version": "10.2.0",
             "dev": true,
             "inBundle": true,
             "license": "MIT",
@@ -8350,12 +8363,12 @@
             }
         },
         "node_modules/npm/node_modules/libnpmdiff": {
-            "version": "8.1.6",
+            "version": "8.1.10",
             "dev": true,
             "inBundle": true,
             "license": "ISC",
             "dependencies": {
-                "@npmcli/arborist": "^9.4.3",
+                "@npmcli/arborist": "^9.8.0",
                 "@npmcli/installed-package-contents": "^4.0.0",
                 "binary-extensions": "^3.0.0",
                 "diff": "^8.0.2",
@@ -8369,13 +8382,13 @@
             }
         },
         "node_modules/npm/node_modules/libnpmexec": {
-            "version": "10.2.6",
+            "version": "10.3.0",
             "dev": true,
             "inBundle": true,
             "license": "ISC",
             "dependencies": {
                 "@gar/promise-retry": "^1.0.0",
-                "@npmcli/arborist": "^9.4.3",
+                "@npmcli/arborist": "^9.8.0",
                 "@npmcli/package-json": "^7.0.0",
                 "@npmcli/run-script": "^10.0.0",
                 "ci-info": "^4.0.0",
@@ -8392,12 +8405,12 @@
             }
         },
         "node_modules/npm/node_modules/libnpmfund": {
-            "version": "7.0.20",
+            "version": "7.0.24",
             "dev": true,
             "inBundle": true,
             "license": "ISC",
             "dependencies": {
-                "@npmcli/arborist": "^9.4.3"
+                "@npmcli/arborist": "^9.8.0"
             },
             "engines": {
                 "node": "^20.17.0 || >=22.9.0"
@@ -8417,12 +8430,12 @@
             }
         },
         "node_modules/npm/node_modules/libnpmpack": {
-            "version": "9.1.6",
+            "version": "9.1.10",
             "dev": true,
             "inBundle": true,
             "license": "ISC",
             "dependencies": {
-                "@npmcli/arborist": "^9.4.3",
+                "@npmcli/arborist": "^9.8.0",
                 "@npmcli/run-script": "^10.0.0",
                 "npm-package-arg": "^13.0.0",
                 "pacote": "^21.0.2"
@@ -8432,7 +8445,7 @@
             }
         },
         "node_modules/npm/node_modules/libnpmpublish": {
-            "version": "11.1.3",
+            "version": "11.2.0",
             "dev": true,
             "inBundle": true,
             "license": "ISC",
@@ -8476,7 +8489,7 @@
             }
         },
         "node_modules/npm/node_modules/libnpmversion": {
-            "version": "8.0.3",
+            "version": "8.0.4",
             "dev": true,
             "inBundle": true,
             "license": "ISC",
@@ -8492,7 +8505,7 @@
             }
         },
         "node_modules/npm/node_modules/lru-cache": {
-            "version": "11.3.5",
+            "version": "11.5.1",
             "dev": true,
             "inBundle": true,
             "license": "BlueOak-1.0.0",
@@ -8501,7 +8514,7 @@
             }
         },
         "node_modules/npm/node_modules/make-fetch-happen": {
-            "version": "15.0.5",
+            "version": "15.0.6",
             "dev": true,
             "inBundle": true,
             "license": "ISC",
@@ -8667,7 +8680,7 @@
             }
         },
         "node_modules/npm/node_modules/node-gyp": {
-            "version": "12.3.0",
+            "version": "12.4.0",
             "dev": true,
             "inBundle": true,
             "license": "MIT",
@@ -8844,7 +8857,7 @@
             }
         },
         "node_modules/npm/node_modules/pacote": {
-            "version": "21.5.0",
+            "version": "21.5.1",
             "dev": true,
             "inBundle": true,
             "license": "ISC",
@@ -8905,7 +8918,7 @@
             }
         },
         "node_modules/npm/node_modules/postcss-selector-parser": {
-            "version": "7.1.1",
+            "version": "7.1.4",
             "dev": true,
             "inBundle": true,
             "license": "MIT",
@@ -9002,7 +9015,7 @@
             "optional": true
         },
         "node_modules/npm/node_modules/semver": {
-            "version": "7.7.4",
+            "version": "7.8.4",
             "dev": true,
             "inBundle": true,
             "license": "ISC",
@@ -9026,17 +9039,17 @@
             }
         },
         "node_modules/npm/node_modules/sigstore": {
-            "version": "4.1.0",
+            "version": "4.1.1",
             "dev": true,
             "inBundle": true,
             "license": "Apache-2.0",
             "dependencies": {
                 "@sigstore/bundle": "^4.0.0",
-                "@sigstore/core": "^3.1.0",
+                "@sigstore/core": "^3.2.1",
                 "@sigstore/protobuf-specs": "^0.5.0",
-                "@sigstore/sign": "^4.1.0",
-                "@sigstore/tuf": "^4.0.1",
-                "@sigstore/verify": "^3.1.0"
+                "@sigstore/sign": "^4.1.1",
+                "@sigstore/tuf": "^4.0.2",
+                "@sigstore/verify": "^3.1.1"
             },
             "engines": {
                 "node": "^20.17.0 || >=22.9.0"
@@ -9053,12 +9066,12 @@
             }
         },
         "node_modules/npm/node_modules/socks": {
-            "version": "2.8.7",
+            "version": "2.8.9",
             "dev": true,
             "inBundle": true,
             "license": "MIT",
             "dependencies": {
-                "ip-address": "^10.0.1",
+                "ip-address": "^10.1.1",
                 "smart-buffer": "^4.2.0"
             },
             "engines": {
@@ -9127,7 +9140,7 @@
             }
         },
         "node_modules/npm/node_modules/tar": {
-            "version": "7.5.13",
+            "version": "7.5.16",
             "dev": true,
             "inBundle": true,
             "license": "BlueOak-1.0.0",
@@ -9155,7 +9168,7 @@
             "license": "MIT"
         },
         "node_modules/npm/node_modules/tinyglobby": {
-            "version": "0.2.16",
+            "version": "0.2.17",
             "dev": true,
             "inBundle": true,
             "license": "MIT",
@@ -9223,7 +9236,7 @@
             }
         },
         "node_modules/npm/node_modules/undici": {
-            "version": "6.25.0",
+            "version": "6.26.0",
             "dev": true,
             "inBundle": true,
             "license": "MIT",
@@ -10035,9 +10048,9 @@
             }
         },
         "node_modules/react-router": {
-            "version": "7.14.2",
-            "resolved": "https://registry.npmjs.org/react-router/-/react-router-7.14.2.tgz",
-            "integrity": "sha512-yCqNne6I8IB6rVCH7XUvlBK7/QKyqypBFGv+8dj4QBFJiiRX+FG7/nkdAvGElyvVZ/HQP5N19wzteuTARXi5Gw==",
+            "version": "7.18.0",
+            "resolved": "https://registry.npmjs.org/react-router/-/react-router-7.18.0.tgz",
+            "integrity": "sha512-pTTGt8J+ji1NOmYnjzT+bAJy/1zD+Jp4ziO6cL7T3ZLvXKtusO7BpFqlRXitqpcPVqllsIXFHRMt+2/k3Xn6HQ==",
             "license": "MIT",
             "dependencies": {
                 "cookie": "^1.0.1",
@@ -10057,12 +10070,12 @@
             }
         },
         "node_modules/react-router-dom": {
-            "version": "7.14.2",
-            "resolved": "https://registry.npmjs.org/react-router-dom/-/react-router-dom-7.14.2.tgz",
-            "integrity": "sha512-YZcM5ES8jJSM+KrJ9BdvHHqlnGTg5tH3sC5ChFRj4inosKctdyzBDhOyyHdGk597q2OT6NTrCA1OvB/YDwfekQ==",
+            "version": "7.18.0",
+            "resolved": "https://registry.npmjs.org/react-router-dom/-/react-router-dom-7.18.0.tgz",
+            "integrity": "sha512-Fi0yY6kgtKae/Th2xibdWK0KSdYZ4B53Gyf6wRtomOKWgpNm7H7+DyfDhncdz9FKbpS+1jmDhg3F4WoGJ+yFOA==",
             "license": "MIT",
             "dependencies": {
-                "react-router": "7.14.2"
+                "react-router": "7.18.0"
             },
             "engines": {
                 "node": ">=20.0.0"
@@ -12074,9 +12087,9 @@
             }
         },
         "node_modules/undici": {
-            "version": "7.25.0",
-            "resolved": "https://registry.npmjs.org/undici/-/undici-7.25.0.tgz",
-            "integrity": "sha512-xXnp4kTyor2Zq+J1FfPI6Eq3ew5h6Vl0F/8d9XU5zZQf1tX9s2Su1/3PiMmUANFULpmksxkClamIZcaUqryHsQ==",
+            "version": "7.28.0",
+            "resolved": "https://registry.npmjs.org/undici/-/undici-7.28.0.tgz",
+            "integrity": "sha512-cRZYrTDwWznlnRiPjggAGxZXanty6M8RV1ff8Wm4LWXBp7/IG8v5DnOm74DtUBp9OONpK75YlPnIjQqX0dBDtA==",
             "dev": true,
             "license": "MIT",
             "engines": {
@@ -12208,9 +12221,9 @@
             }
         },
         "node_modules/vite": {
-            "version": "6.4.2",
-            "resolved": "https://registry.npmjs.org/vite/-/vite-6.4.2.tgz",
-            "integrity": "sha512-2N/55r4JDJ4gdrCvGgINMy+HH3iRpNIz8K6SFwVsA+JbQScLiC+clmAxBgwiSPgcG9U15QmvqCGWzMbqda5zGQ==",
+            "version": "6.4.3",
+            "resolved": "https://registry.npmjs.org/vite/-/vite-6.4.3.tgz",
+            "integrity": "sha512-NTKlcQjlAK7MlQoyb6LgaqHc8sso/pVyUJYWMws3jg21uTJw/LddqIFPcPqP6PzpgbIcZyKI85sFE4HBrQDA8A==",
             "dev": true,
             "license": "MIT",
             "dependencies": {


### PR DESCRIPTION
The CI lint job's 'npm audit --audit-level=high' step has been failing since the Vite migration. The flagged highs are all build-time/dev advisories (vite, undici, fast-uri) plus react-router's __manifest-endpoint DoS, none of which are reachable in this client-only static SPA. 'npm audit fix' (no --force) resolves all of them within the existing semver ranges, so package.json is unchanged and only package-lock.json moves (e.g. react-router-dom 7.14.2->7.18.0, vite 6.4.2->6.4.3).

Verified: vite build, eslint, prettier all pass, npm audit reports 0 vulnerabilities, and the app still works (audio-off URL redirect, mid-session mute toggle, PLAY audio, animation, themed icons).